### PR TITLE
Support for -t and --type

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ec2-price
 ----
 
-Retrieve the latest EC2 price via a command line.
+Retrieve the latest EC2 prices via command line.
 
 ## Installation
 
@@ -25,13 +25,13 @@ You can specify a region.
 $ ec2-price --region us-east-1
 ```
 
-You can specify a type across all regions.
+You can specify a particular type across all regions.
 
 ````shell
 $ ec-price --type c4.2xlarge
 ````
 
-Finally, you can specify a region and type.
+You can specify a region and a particular type.
 
 ````shell
 $ ec2-price --region us-west-1 --type c4.2xlarge

--- a/README.md
+++ b/README.md
@@ -15,12 +15,18 @@ npm install ec2-price -g
 
 Output all prices in all regions.
 
-```
+```shell
 $ ec2-price
 ```
 
 You can specify a region.
 
-```
+```shell
 $ ec2-price --region us-east-1
 ```
+
+You can specify a region and type.
+
+````shell
+$ ec2-price --region us-west-1 --type c4.2xlarge
+````

--- a/README.md
+++ b/README.md
@@ -25,7 +25,13 @@ You can specify a region.
 $ ec2-price --region us-east-1
 ```
 
-You can specify a region and type.
+You can specify a type across all regions.
+
+````shell
+$ ec-price --type c4.2xlarge
+````
+
+Finally, you can specify a region and type.
 
 ````shell
 $ ec2-price --region us-west-1 --type c4.2xlarge

--- a/index.js
+++ b/index.js
@@ -22,11 +22,11 @@ if (argv.h || argv.help) {
   console.log('  ec2-price [-r region] [-t type]');
   console.log();
   console.log('Options:');
-  console.log('  -h, --help       help message');
-  console.log('  -v, --verbose    output price with the instance spec');
-  console.log('      --version    version info');
-  console.log('  -r, --region [REGION]   specify region (%s)');
-  console.log('  -t, --type [TYPE]   specify a type (%s)');
+  console.log('  -h, --help            help message');
+  console.log('  -v, --verbose         output price with the instance spec');
+  console.log('      --version         version info');
+  console.log('  -r, --region [REGION] specify a region');
+  console.log('  -t, --type [TYPE]     specify a type');
   process.exit();
 }
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
-var fetch = require('node-fetch')
-var argv = require('minimist')(process.argv.slice(2))
-var columnify = require('columnify')
+var fetch = require('node-fetch');
+var argv = require('minimist')(process.argv.slice(2));
+var columnify = require('columnify');
 
-const AWS_PRICE_JS_URL = 'http://a0.awsstatic.com/pricing/1/ec2/linux-od.min.js'
+const AWS_PRICE_JS_URL = 'http://a0.awsstatic.com/pricing/1/ec2/linux-od.min.js';
 const AWS_REGIONS = [
   'ap-northeast-1',
   'ap-southeast-1',
@@ -14,18 +14,19 @@ const AWS_REGIONS = [
   'us-gov-west-1',
   'us-west-1',
   'us-west-2',
-]
+];
 
 // help
 if (argv.h || argv.help) {
   console.log('Usage:');
-  console.log('  ec2-price [-r region]');
+  console.log('  ec2-price [-r region] [-t type]');
   console.log();
   console.log('Options:');
   console.log('  -h, --help       help message');
   console.log('  -v, --verbose    output price with the instance spec');
   console.log('      --version    version info');
   console.log('  -r, --region [REGION]   specify region (%s)');
+  console.log('  -t, --type [TYPE]   specify a type (%s)');
   process.exit();
 }
 
@@ -47,48 +48,56 @@ if (_region) {
   }
 }
 
+// type
+var _type = argv.t || argv.type;
+
 fetch(AWS_PRICE_JS_URL)
   .then(function(res) {
     return res.text();
   }).then(function(body) {
     var callback = function(obj) {
-      var selected_region = (_region) ? obj.config.regions.filter(function(i) { return i.region == _region }) : obj.config.regions
+      var selected_region = (_region) ? obj.config.regions.filter(function(i) { return i.region == _region; }) : obj.config.regions;
 
       for (var region of selected_region) {
-        console.log('REGION: ' + region.region) 
-        console.log('----------------------')
-        var price_data = []
+        console.log('REGION: ' + region.region);
+        console.log('----------------------');
+        var price_data = [];
 
         for (var instanceType of region.instanceTypes) {
           for (var size of instanceType.sizes) {
-            data = {}
+            data = {};
 
-            if (argv.v) {
-              data = { 
+            if(_type && size.size != _type) {
+                continue;
+            }
+
+            if (argv.v || argv.verbose) {
+              data = {
                 name: size.size,
                 "v-CPU": size.vCPU,
                 ECU: size.ECU,
                 memory: size.memoryGiB,
                 strorage: size.storageGB,
                 price: size.valueColumns[0].prices.USD,
-              }
+              };
             } else {
               data = {
                 name: size.size,
                 price: size.valueColumns[0].prices.USD,
-              }
+              };
             }
-            
+
             price_data.push(data);
           }
         }
         console.log(columnify(price_data));
-        console.log(''); 
+        console.log('');
       }
     };
 
     eval(body);
   }).catch(function(e) {
-    console.log(e);
+    console.error(e);
+    exit(1);
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ec2-price",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "index.js",
   "dependencies": {
     "columnify": "^1.5.1",
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/toshimaru/ec2-price.git"
+    "url": "https://github.com/toshimaru/ec2-price.git"
   },
   "keywords": [
     "ec2",
@@ -25,6 +25,6 @@
     "url": "https://github.com/toshimaru/ec2-price/issues"
   },
   "homepage": "https://github.com/toshimaru/ec2-price",
-  "description": "Get the latest EC2 price via a command line. ",
+  "description": "Get the latest EC2 price via a command line.",
   "bin": "bin/ec2-price"
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
     "url": "https://github.com/toshimaru/ec2-price/issues"
   },
   "homepage": "https://github.com/toshimaru/ec2-price",
-  "description": "Get the latest EC2 price via a command line.",
+  "description": "Get the latest EC2 prices via command line.",
   "bin": "bin/ec2-price"
 }


### PR DESCRIPTION
Support for passing `-t` or `--type` which lists all instances of a given type. You can mix with `--region` as well. Also fixes a bug, where `--verbose` did not work, only `-v` worked.
